### PR TITLE
Add dev build tag to Go tests in release workflow

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -28,7 +28,7 @@ jobs:
           node-version: 20
 
       - name: Run Go tests
-        run: go test ./... -v -race
+        run: go test -tags dev ./... -v -race
 
       - name: Run frontend tests
         run: cd web && npm ci && npx vitest run


### PR DESCRIPTION
## Summary
Updated the Go test command in the release workflow to include the `dev` build tag when running tests.

## Changes
- Modified the `Run Go tests` step in `.github/workflows/release.yml` to include `-tags dev` flag in the `go test` command
- This ensures tests are run with development-specific build constraints enabled

## Details
The change allows Go tests to be executed with the `dev` build tag, which may be necessary for:
- Running tests that are only compiled when the `dev` tag is present
- Ensuring development-specific code paths are tested during the release process
- Maintaining consistency with how tests should be run in a development context

https://claude.ai/code/session_015gPidXRzaKvSF9NJt7Vi2b